### PR TITLE
fix: update BlurFade component in Home page to remove y offset

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,7 +15,7 @@ const BLUR_FADE_DELAY = 0.04;
 export default function Home() {
   return (
     <section className="container max-w-4xl py-20">
-      <BlurFade delay={BLUR_FADE_DELAY}>
+      <BlurFade delay={BLUR_FADE_DELAY} yOffset={0}>
         <Intro />
       </BlurFade>
       <BlurFade delay={BLUR_FADE_DELAY * 3}>


### PR DESCRIPTION
Add 0 yOffset to BlurFade component so that the display does not shift on load.