### PR TITLE
Chore/ignore admin analytics

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Next.js: debug server-side",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "npm run dev"
+    },
+    {
+      "name": "Next.js: debug client-side",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:3000"
+    },
+    {
+      "name": "Next.js: debug full stack",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/node_modules/.bin/next",
+      "runtimeArgs": ["--inspect"],
+      "skipFiles": ["<node_internals>/**"],
+      "serverReadyAction": {
+        "action": "debugWithEdge",
+        "killOnServerStop": true,
+        "pattern": "- Local:.+(https?://.+)",
+        "uriFormat": "%s",
+        "webRoot": "${workspaceFolder}"
+      }
+    }
+  ]
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
 import { Inter, Playfair_Display } from 'next/font/google';
 
 import { Analytics } from '@vercel/analytics/react';
@@ -6,12 +7,12 @@ import { Analytics } from '@vercel/analytics/react';
 import { ThemeProvider } from '@/components/theme-provider';
 import Footer from '@/components/footer';
 import { Toaster } from '@/components/ui/sonner';
+import Navbar from '@/components/navbar';
+import { TooltipProvider } from '@/components/ui/tooltip';
 
 import { cn } from '@/lib/utils';
 
 import '../styles/globals.css';
-import Navbar from '@/components/navbar';
-import { TooltipProvider } from '@/components/ui/tooltip';
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-sans' });
 const playfairDisplay = Playfair_Display({
@@ -34,6 +35,9 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const cookieStore = cookies();
+  const isAdmin = cookieStore.get('isAdmin');
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body
@@ -56,7 +60,7 @@ export default function RootLayout({
           </TooltipProvider>
         </ThemeProvider>{' '}
         <Toaster />
-        <Analytics />
+        {!isAdmin && <Analytics />}
       </body>
     </html>
   );


### PR DESCRIPTION
Refactor Layout so that analytics does not count my own visit

The changes include:
- Importing the 'cookies' module from 'next/headers'
- Adding a 'cookieStore' variable to retrieve cookies
- Adding an 'isAdmin' variable to check if the user is an admin
- Conditionally rendering the <Analytics /> component based on the 'isAdmin' variable